### PR TITLE
remove site-wide smooth-scrolling default

### DIFF
--- a/src/styles/customize.css
+++ b/src/styles/customize.css
@@ -8,7 +8,6 @@ html {
   font-family: "Roboto", sans-serif;
   color: #444;
   font-size: 12pt;
-  scroll-behavior: smooth;
 }
 
 a {


### PR DESCRIPTION
addresses:

> Can we make switching between pages (ie, “Frequent Next Steps” links) just go to the TOP of the page without the scrolling?
