### PR TITLE
make in-page cloud costs links jump to their destination

### DIFF
--- a/src/pages/user-resources/usage-costs.mdx
+++ b/src/pages/user-resources/usage-costs.mdx
@@ -77,7 +77,7 @@ NHLBI BDC Pilot Funding Program recipients agree to acknowledge the funding in a
 Prior to applying for Pilot Credits, applicants must [create an account(s) and project or workspace](/use-bdc/analyze-data) in the platform(s) aligned with their Pilot Credit request. For more information about the differences between BDC's standard workspaces and those provided by *BDC Powered by Terra*, [visit this webpage](/use-bdc/analyze-data/bdc-workspaces).
 
 <ButtonContainer>
-  <ButtonLink to="/user-resources/usage-costs/#cloud-credit-request-form">Fill out the form below to request $500 in pilot cloud credits.</ButtonLink>
+  <ButtonLink component="a" href="#cloud-credit-request-form">Fill out the form below to request $500 in pilot cloud credits.</ButtonLink>
 </ButtonContainer>
 
 ### NHLBI BDC Cloud Credit Support Program
@@ -89,7 +89,7 @@ NHLBI BDC Cloud Credit Support Program recipients agree to acknowledge the fundi
 Applicants for the NHLBI BDC Cloud Credit Support Program must specify the BDC platform they will use: either *BDC-Seven Bridges* or *BDC-Terra*. Before applying for Cloud Credit Support, applicants must [create an account in the platform aligned with their Cloud Credit Support request](/use-bdc/analyze-data). For more information about the differences between BDC's standard workspaces and those provided by *BDC Powered by Terra*, [visit this webpage](/use-bdc/analyze-data/bdc-workspaces).
 
 <ButtonContainer>
-  <ButtonLink to="/user-resources/usage-costs/#cloud-credit-request-form">Fill out the form below to request $500 in pilot cloud credits.</ButtonLink>
+  <ButtonLink component="a" href="/user-resources/usage-costs/#cloud-credit-request-form">Fill out the form below to request $500 in pilot cloud credits.</ButtonLink>
 </ButtonContainer>
 
 ### Cloud Credit Requests for Academic Classes and Group Educational Sessions

--- a/src/styles/customize.css
+++ b/src/styles/customize.css
@@ -8,7 +8,6 @@ html {
   font-family: "Roboto", sans-serif;
   color: #444;
   font-size: 12pt;
-  scroll-behavior: smooth;
 }
 
 a {


### PR DESCRIPTION
addresses:

> Neither the button within the NHLBI BDC Pilot Funding Program nor the button within the NHLBI BDC Cloud Credit Support Program actually go to the form when clicked. (note that the anchor tag in URL is changing to … /#cloud-credit-request-form)
