### PR TITLE
Bugfix/link

### DIFF
--- a/src/components/buttons/button-link.js
+++ b/src/components/buttons/button-link.js
@@ -21,7 +21,7 @@ const StyledButton = styled(Button)`
 
 export const ButtonLink = props => {
   return (
-    <StyledButton as={ Link } { ...props } />
+    <StyledButton as={ Link } lightIcon { ...props } />
   )
 };
 

--- a/src/components/buttons/button-link.js
+++ b/src/components/buttons/button-link.js
@@ -1,6 +1,6 @@
+import React from 'react';
 import styled from "styled-components";
-import { Link } from "gatsby";
-// import { Link } from "../link";
+import { Link } from "../link";
 import { Button } from "./button";
 
 const transitionBrightness = `
@@ -11,13 +11,19 @@ const transitionBrightness = `
     }
 `;
 
-export const ButtonLink = styled(Button).attrs({ as: Link })`
+const StyledButton = styled(Button)`
   ${transitionBrightness};
   text-align: center;
   max-width: 100%;
   text-wrap: wrap;
   line-height: 1.5;
-`; 
+`
+
+export const ButtonLink = props => {
+  return (
+    <StyledButton as={ Link } { ...props } />
+  )
+};
 
 export const ButtonExternalLink = styled(ButtonLink)
   .attrs({ rel: 'noopener noreferrer', target: '_blank' })`

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -2,11 +2,19 @@ import React from 'react'
 import { Link as GatsbyLink } from 'gatsby'
 import { ExternalLink } from './external-link'
 
+const hashPattern = new RegExp(/^#(.+)$/);
+const externalUrlPattern = new RegExp(/^https?:\/\//);
+
 export const Link = ({ to, children, ...props }) => {
-  const externalUrlPattern = new RegExp(/^https?:\/\//)
-  const match = externalUrlPattern.exec(to)
-  if (match) {
+  const isExternalLink = externalUrlPattern.exec(to)
+  if (isExternalLink) {
     return <ExternalLink to={ to } { ...props }>{ children }</ExternalLink>
   }
-  return <GatsbyLink to={ to } { ...props }>{ children }</GatsbyLink>
+
+  const hashLink = hashPattern.exec(to);
+  if (hashLink) {
+    return <a href={ to } { ...props }>{ children }</a>;
+  }
+
+  return <GatsbyLink to={ to } { ...props }>{ children }</GatsbyLink>;
 }

--- a/src/pages/user-resources/usage-costs.mdx
+++ b/src/pages/user-resources/usage-costs.mdx
@@ -75,7 +75,7 @@ NHLBI BDC Pilot Funding Program recipients agree to acknowledge the funding in a
 Prior to applying for Pilot Credits, applicants must [create an account(s) and project or workspace](/use-bdc/analyze-data) in the platform(s) aligned with their Pilot Credit request. For more information about the differences between BDC's standard workspaces and those provided by *BDC Powered by Terra*, [visit this webpage](/use-bdc/analyze-data/bdc-workspaces).
 
 <ButtonContainer>
-  <ButtonLink component="a" href="#cloud-credit-request-form">Fill out the form below to request $500 in pilot cloud credits</ButtonLink>
+  <ButtonLink to="#cloud-credit-request-form">Fill out the form below to request $500 in pilot cloud credits</ButtonLink>
 </ButtonContainer>
 
 ### NHLBI BDC Cloud Credit Support Program
@@ -87,7 +87,7 @@ NHLBI BDC Cloud Credit Support Program recipients agree to acknowledge the fundi
 Applicants for the NHLBI BDC Cloud Credit Support Program must specify the BDC platform they will use: either *BDC-Seven Bridges* or *BDC-Terra*. Before applying for Cloud Credit Support, applicants must [create an account in the platform aligned with their Cloud Credit Support request](/use-bdc/analyze-data). For more information about the differences between BDC's standard workspaces and those provided by *BDC Powered by Terra*, [visit this webpage](/use-bdc/analyze-data/bdc-workspaces).
 
 <ButtonContainer>
-  <ButtonLink component="a" href="/user-resources/usage-costs/#cloud-credit-request-form">Fill out the form below to apply for the NHLBI BDC Cloud Credit Support Program</ButtonLink>
+  <ButtonLink to="/user-resources/usage-costs/#cloud-credit-request-form">Fill out the form below to apply for the NHLBI BDC Cloud Credit Support Program</ButtonLink>
 </ButtonContainer>
 
 ### Cloud Credit Requests for Academic Classes and Group Educational Sessions


### PR DESCRIPTION
this closes #23 , which is a larger issue than the title conveys.

it turns out, the ButtonLink component, defined like `const ButtonLink = styled(Button).attrs({ as: Link })`,
incorrectly uses `attrs`, as here `as` would be passed to the underlying DOM element and thus is not telling styled-components to use the Link component. thus the `to` prop (as in <ButtonLink to="#somewhere">) doesn't ever get consumed by a Link component. this PR fixes that issue.

additionally, @reach/router doesn't seem to behave as expected with any of the `#down-the-page` URLs, but an old reliable `<a>` tag does. therefore, we add a second check for internal links to see if they are in-page anchors, and we use an `<a>` tag in that case.