### PR TITLE
switch Button usage to ButtonLink component

### DIFF
--- a/src/pages/use-bdc/analyze-data/index.mdx
+++ b/src/pages/use-bdc/analyze-data/index.mdx
@@ -20,7 +20,7 @@ import {
   FloatingTextWrapper,
   PageContent,
 } from "../../../components/layout"
-import { Button, ButtonContainer } from "../../../components/buttons";
+import { ButtonLink, ButtonContainer } from "../../../components/buttons";
 import { NextStepsCard } from "../../../components/card"
 import { Link } from "../../../components/link"
 
@@ -64,7 +64,7 @@ To build a cohort for analysis using data available in BDC, researchers must hav
 Users building cohorts will see exact counts and can import the selected data into a BDC workspace. The ["Select and Package Data" section in the BDC documentation](https://bdcatalyst.gitbook.io/biodata-catalyst-documentation/written-documentation/explore-available-data/pic-sure-for-biodata-catalyst-user-guide/pic-sure-open-access-vs.-pic-sure-authorized-access/search-authorized-access\#select-and-package-data+) provides more information about importing a cohort to a BDC workspace.
 
 <ButtonContainer>
-  <Button as="a" href="https://picsure.biodatacatalyst.nhlbi.nih.gov/login" className="GTM-button" id="cohort-analysis">Build a Cohort for Analysis</Button>
+  <ButtonLink to="https://picsure.biodatacatalyst.nhlbi.nih.gov/login" className="GTM-button" id="cohort-analysis">Build a Cohort for Analysis</ButtonLink>
 </ButtonContainer>
 
 ## Import Data to a BDC Workspace


### PR DESCRIPTION
I missed this the first time around where on the `/analyze-data/index.js` page, the Button uses the old `Button` component that doesn't utilize our Link component. This commit just switches it over to the newer `ButtonLink` component which uses our custom link component and gives us the functionality to open external links in a new tab.