### PR TITLE
specify SameSite for cookies in Google Analytics plugin config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -183,6 +183,12 @@ module.exports = {
       options: {
         trackingIds: ["G-2M4JYYSBD3"],
       },
+      gtagConfig: {
+        cookie_flags: 'SameSite=None;Secure'
+      },
+      pluginConfig: {
+        head: true,
+      },
     },
   ]
 };


### PR DESCRIPTION
this PR attempts to fix a missing cookie setting, which is related to security requirements