### PR TITLE
Program studies count

### DIFF
--- a/src/components/program-studies/programs-panel.js
+++ b/src/components/program-studies/programs-panel.js
@@ -28,7 +28,7 @@ export const Programs = ({
     key: name,
     title: name,
     subtitle: description,
-    additionalData: `${compactNum(numberOfStudies)} stud${new Intl.PluralRules("en-US").select(numberOfStudies) === "one" ? "y" : "ies"}`
+    additionalData: `${compactNum(numberOfStudies)} dataset${new Intl.PluralRules("en-US").select(numberOfStudies) === "one" ? "" : "s"}`
   }));
 
   return (

--- a/src/components/program-studies/vertical-tabs.js
+++ b/src/components/program-studies/vertical-tabs.js
@@ -70,8 +70,7 @@ export const Tabs = ({
           </TabHeader>
           <TabDescription>
             <Subtitle>{subtitle}</Subtitle>
-            {/* removing currently incorrect #studies */}
-            <AdditionalData>&nbsp;</AdditionalData>
+            <AdditionalData>{additionalData}</AdditionalData>
           </TabDescription>
         </Tab>
       ))}


### PR DESCRIPTION
this PR brings back the studies count, _except_, to account for the miscount, we're not calling them "studies" anymore;  we're now calling them "datasets."