### PR TITLE
234 add research community dropdown to all forms

### DIFF
--- a/src/components/forms/cloud-credits.js
+++ b/src/components/forms/cloud-credits.js
@@ -212,6 +212,7 @@ export const CloudCreditsForm = (props) => {
       }
       return {
         ...payload,
+        cf_research_community: selectedResearchCommunity,
         cf_by_submitting_this_form_i_agree_to_the_terms_and_conditions_of_this_offering: consent,
       };
     };
@@ -224,7 +225,6 @@ export const CloudCreditsForm = (props) => {
       status: 2,
       name: name,
       email: email,
-      cf_research_community: selectedResearchCommunity,
       custom_fields: { ...customFieldsPayload(oneRequest) },
     };
 

--- a/src/components/forms/cloud-credits.js
+++ b/src/components/forms/cloud-credits.js
@@ -212,7 +212,8 @@ export const CloudCreditsForm = (props) => {
       }
       return {
         ...payload,
-        cf_research_community: selectedResearchCommunity,
+        cf_research_community: researchCommunity, 
+        cf_other_research_community: otherResearchCommunity || "", 
         cf_by_submitting_this_form_i_agree_to_the_terms_and_conditions_of_this_offering: consent,
       };
     };

--- a/src/components/forms/cloud-credits.js
+++ b/src/components/forms/cloud-credits.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import styled from "styled-components";
 import axios from "axios";
 import { Paragraph } from "../typography";
@@ -80,6 +80,10 @@ export const CloudCreditsForm = (props) => {
   const [hlbsRelation, setHlbsRelation] = useState("");
   const [grapevine, setGrapevine] = useState("");
   const [oneRequest, setOneRequest] = useState("");
+  const [researchCommunity, setResearchCommunity] = useState("");
+  const otherResearchCommunitySelected = useMemo(() => researchCommunity === "Other", [researchCommunity]);
+  const [otherResearchCommunity, setOtherResearchCommunity] = useState("");
+
   // NHLBI BDC Pilot Funding Program
   const [preferredPlatform, setPreferredPlatform] = useState("");
   const [bdcSevenBridgesUsername, setBdcSevenBridgesUsername] = useState("");
@@ -117,6 +121,11 @@ export const CloudCreditsForm = (props) => {
 
     if (honeypotFieldRef.current?.value !== "") return;
 
+    // Use typed value if "Other" is selected, otherwise use the selected option
+    const selectedResearchCommunity = researchCommunity === "Other"
+    ? `Other: ${otherResearchCommunity}`
+    : researchCommunity;
+  
     const description = ``
       + `Requestor's name: ${name} <br />`
       + `Requestor's email: ${email} <br />`
@@ -124,11 +133,12 @@ export const CloudCreditsForm = (props) => {
       + `Project Name: ${projectName}<br />`
       + `Requestor's role: ${role} <br />`
       + `Requestor's organization: ${organization} <br />`
+      + `Requestor's research community: ${selectedResearchCommunity} <br />`
       + `Team members: ${teamMembers} <br />`
       + `How is your research related to HLBS?: ${hlbsRelation} <br />`
       + `How did the requestor learn about BDC?: ${grapevine} <br />`
       + `Request: ${oneRequest} <br /><br />`
-
+ 
     const customFieldsDescription = option => {
       if (option === "NHLBI BDC Pilot Funding Program") {
         let response = `Preferred analysis platform: ${ preferredPlatform } <br />`
@@ -214,6 +224,7 @@ export const CloudCreditsForm = (props) => {
       status: 2,
       name: name,
       email: email,
+      cf_research_community: selectedResearchCommunity,
       custom_fields: { ...customFieldsPayload(oneRequest) },
     };
 
@@ -247,6 +258,8 @@ export const CloudCreditsForm = (props) => {
   const handleChangeEmail = (event) => setEmail(event.target.value);
   const handleChangeRole = (event) => setRole(event.target.value);
   const handleChangeOrganization = (event) => setOrganization(event.target.value);
+  const handleChangeResearchCommunity = (event) => setResearchCommunity(event.target.value);
+  const handleChangeOtherResearchCommunity = (event) => setOtherResearchCommunity(event.target.value);
   const handleChangeProjectName = (event) => setProjectName(event.target.value);
   const handleChangeTeamMembers = (event) => setTeamMembers(event.target.value);
   const handleChangeHlbsRelation = (event) => setHlbsRelation(event.target.value);
@@ -361,6 +374,75 @@ export const CloudCreditsForm = (props) => {
               onChange={handleChangeOrganization}
             />
           </FormControl>
+          <FormControl>
+            <label required htmlFor="researchCommunity">
+              Select a Research Community *
+            </label>
+            <Select
+              id="researchCommunity"
+              name="researchCommunity"
+              value={researchCommunity}
+              onChange={handleChangeResearchCommunity}
+            >
+              <Option value="">Select One</Option>
+              <Option value="Bench to Bassinet">
+                Bench to Bassinet
+              </Option>
+              <Option value="BioLINCC">
+                BioLINCC
+              </Option>
+              <Option value="C4R">
+                C4R
+              </Option>
+              <Option value="CONNECTS">
+                CONNECTS
+              </Option>
+              <Option value="Cure Sickle Cell Initiative">
+                Cure Sickle Cell Initiative
+              </Option>
+              <Option value="HeartShare">
+                HeartShare
+              </Option>
+              <Option value="LungMAP">
+                LungMAP
+              </Option>
+              <Option value="NSRR">
+                NSRR
+              </Option>
+              <Option value="Pediatric Heart Network">
+                Pediatric Heart Network
+              </Option>
+              <Option value="PETAL Network">
+                PETAL Network
+              </Option>
+              <Option value="RECOVER">
+                RECOVER
+              </Option>
+              <Option value="RMIP">
+                RMIP
+              </Option>
+              <Option value="TOPMed">
+                TOPMed
+              </Option>
+              <Option value="Other">
+                Other
+              </Option>
+            </Select>
+          </FormControl>
+          {otherResearchCommunitySelected && (
+            <FormControl>
+              <label required htmlFor="other-research-community">
+                Name of Research Community
+              </label>
+              <TextInput
+                id="other-research-community"
+                name="other-research-community"
+                value={otherResearchCommunity}
+                onChange={handleChangeOtherResearchCommunity}
+                maxLength="3000"
+              />
+            </FormControl>
+          )}
           <FormControl>
             <label htmlFor="project-name">Project Name *</label>
             <TextInput

--- a/src/components/forms/join.js
+++ b/src/components/forms/join.js
@@ -51,6 +51,11 @@ export const JoinForm = (props) => {
   const [otherFieldOfStudy, setOtherFieldOfStudy] = useState("");
   
   const [interest, setInterest] = useState("");
+  const [researchCommunity, setResearchCommunity] = useState("");
+
+  const otherResearchCommunitySelected = useMemo(() => researchCommunity === "Other", [researchCommunity]);
+  const [otherResearchCommunity, setOtherResearchCommunity] = useState("");
+
   const otherInterestSelected = useMemo(() => interest === "Other", [interest]);
   const [otherInterest, setOtherInterest] = useState("");
   
@@ -113,6 +118,8 @@ export const JoinForm = (props) => {
 
   const handleChangeOtherField = (event) => setOtherFieldOfStudy(event.target.value);
   const handleChangeInterest = (event) => setInterest(event.target.value);
+  const handleChangeResearchCommunity = (event) => setResearchCommunity(event.target.value);
+  const handleChangeOtherResearchCommunity = (event) => setOtherResearchCommunity(event.target.value);
   const handleChangeOtherInterest = (event) => setOtherInterest(event.target.value);
 
   const handleChangeGrapevine = (event) => setGrapevine(event.target.value);
@@ -242,6 +249,76 @@ export const JoinForm = (props) => {
                   />
                 </FormControl>
               )}
+              <FormControl>
+                <label required htmlFor="researchCommunity">
+                  Select a Research Community
+                </label>
+                <Select
+                  id="researchCommunity"
+                  name="researchCommunity"
+                  value={researchCommunity}
+                  onChange={handleChangeResearchCommunity}
+                >
+                  <Option value="">Select One</Option>
+                  <Option value="Bench to Bassinet">
+                    Bench to Bassinet
+                  </Option>
+                  <Option value="BioLINCC">
+                    BioLINCC
+                  </Option>
+                  <Option value="C4R">
+                    C4R
+                  </Option>
+                  <Option value="CONNECTS">
+                    CONNECTS
+                  </Option>
+                  <Option value="Cure Sickle Cell Initiative">
+                    Cure Sickle Cell Initiative
+                  </Option>
+                  <Option value="HeartShare">
+                    HeartShare
+                  </Option>
+                  <Option value="LungMAP">
+                    LungMAP
+                  </Option>
+                  <Option value="NSRR">
+                    NSRR
+                  </Option>
+                  <Option value="Pediatric Heart Network">
+                    Pediatric Heart Network
+                  </Option>
+                  <Option value="PETAL Network">
+                    PETAL Network
+                  </Option>
+                  <Option value="RECOVER">
+                    RECOVER
+                  </Option>
+                  <Option value="RMIP">
+                    RMIP
+                  </Option>
+                  <Option value="TOPMed">
+                    TOPMed
+                  </Option>
+                  <Option value="Other">
+                    Other
+                  </Option>
+                </Select>
+              </FormControl>
+              {otherResearchCommunitySelected && (
+                <FormControl>
+                  <label required htmlFor="other-research-community">
+                    Name of Research Community
+                  </label>
+                  <TextInput
+                    id="other-research-community"
+                    name="other-research-community"
+                    value={otherResearchCommunity}
+                    onChange={handleChangeOtherResearchCommunity}
+                    maxLength="3000"
+                  />
+                </FormControl>
+              )}
+
               <FormControl>
                 <label required htmlFor="interest">
                   Why are you joining BDC? *

--- a/src/components/forms/join.js
+++ b/src/components/forms/join.js
@@ -78,8 +78,8 @@ export const JoinForm = (props) => {
         contacts_field: fieldOfStudy.toString(),
         contacts_other: otherFieldOfStudy,
         contacts_interest: interest,
-        cf_research_community: researchCommunity,
-        cf_other_research_community: otherResearchCommunity,
+        contact_research_community: researchCommunity,
+        contact_other_research_community: otherResearchCommunity,
       },
     };
 
@@ -253,7 +253,7 @@ export const JoinForm = (props) => {
               )}
               <FormControl>
                 <label required htmlFor="researchCommunity">
-                  Select a Research Community
+                  Select a Research Community *
                 </label>
                 <Select
                   id="researchCommunity"

--- a/src/components/forms/join.js
+++ b/src/components/forms/join.js
@@ -78,6 +78,8 @@ export const JoinForm = (props) => {
         contacts_field: fieldOfStudy.toString(),
         contacts_other: otherFieldOfStudy,
         contacts_interest: interest,
+        cf_research_community: researchCommunity,
+        cf_other_research_community: otherResearchCommunity,
       },
     };
 


### PR DESCRIPTION
This PR will add "Research Community" field the following forms
- Cloud Credits Form
  - Tested and correctly creates new ticket in FreshDesk
- Join the Community Form
  - Tested and correctly creates new contact in FreshDesk
- Contact Us Form
  - Needs to be turned on from the FreshDesk side (`Admin > Ticket Fields > Research Community`, select "can view" and "can edit" under "Behavior For Customers")
  - Note: Ensure that the "Name of Research Community" field is also turned on by selecting "can view" and "can edit" under "Behavior For Customers"