### PR TITLE
Staging - add gov shutdown banner

### DIFF
--- a/src/data/banners/gov-shutdown.mdx
+++ b/src/data/banners/gov-shutdown.mdx
@@ -1,10 +1,6 @@
 ---
 variant: alert
-active: false
+active: true
 importance: 1
 ---
-Because of a lapse in government funding, the information on this website may not be up to date, transactions submitted via the website may not be processed, and the agency may not be able to respond to inquiries until appropriations are enacted.
-
-The NIH Clinical Center (the research hospital of NIH) is open. For more details about its operating status, please visit [cc.nih.gov](http://cc.nih.gov/).
-
-Updates regarding government operating status and resumption of normal operations can be found at [opm.gov](http://opm.gov/).
+Because of a lapse in government funding, the information on this website may not be up to date, transactions submitted via the website may not be processed, and the agency may not be able to respond to inquiries until appropriations are enacted. The NIH Clinical Center (the research hospital of NIH) is open. For more details about its operating status, please visit [cc.nih.gov](http://cc.nih.gov/). Updates regarding government operating status and resumption of normal operations can be found at [opm.gov](http://opm.gov/).


### PR DESCRIPTION
The text for the shutdown banner comes from NIH/NHLBI via an email on 9/30/2025.

Official go-ahead was received via email from NIH/NHLBI at 9:47am on 10/01/2025.