### PR TITLE
265 update page content add phn button to research communities page

### DIFF
--- a/src/pages/about/research-communities.mdx
+++ b/src/pages/about/research-communities.mdx
@@ -53,7 +53,7 @@ TOPMed is a program of the National Heart, Lung, and Blood Institute (NHLBI), a 
 TOPMed supports scientific advances through the integration of whole-genome sequencing (WGS) and other omics data (e.g., metabolic profiles, epigenomics, protein, and RNA expression patterns) with molecular, behavioral, imaging, environmental, and clinical data from pre-existing parent studies that have large samples of human subjects with rich phenotypic characterization and environmental exposure data. TOPMed also collects environmental and behavioral data, such as dietary habits, physical activity, and socioeconomic factors, to provide a more comprehensive understanding of the factors that contribute to these disorders.
 
 <ButtonContainer>
-  <ButtonLink to="/about/studies?program=TOPMed">See a list of the TOPMed data available in BDC</ButtonLink>
+  <ButtonLink to="/about/studies/?program=TOPMed">See a list of the TOPMed data available in BDC</ButtonLink>
 </ButtonContainer>
 
 ## RECOVER
@@ -77,7 +77,7 @@ The [RECOVER Data Release Notes](https://bdcatalyst.gitbook.io/biodata-catalyst-
 Currently, BDC hosts three RECOVER datasets. The adult observational cohort study represents over 15,200 participants attending more than 121,000 study visits at 83 enrolling sites. The pediatric observational cohort study dataset consists of survey and laboratory results from more than 24,000 young adults, children, infants, and their caregivers who participated in more than 62,000 study visits at 115 enrolling sites. The tissue pathology study data was collected from almost 200 adult decedents across six geographically dispersed enrolling sites.
 
 <ButtonContainer>
-  <ButtonLink to="/about/studies?program=RECOVER">See a list of the RECOVER data available in BDC</ButtonLink>
+  <ButtonLink to="/about/studies/?program=RECOVER">See a list of the RECOVER data available in BDC</ButtonLink>
 </ButtonContainer>
 
 
@@ -86,7 +86,7 @@ Currently, BDC hosts three RECOVER datasets. The adult observational cohort stud
 The [Bench to Bassinet Program](https://benchtobassinet.com/) is a major effort launched by the NHLBI to accelerate scientific discovery to clinical practice by fostering collaborations of basic, translational, and clinical researchers through a flexible program designed to improve outcomes for individuals with congenital heart disease while supporting the needs of the pediatric heart disease research community. Bench to Bassinet advances understanding of how the heart develops and why children are born with heart problems. The information is used to develop new ways to help infants, children, teenagers, and adults born with heart disease. Bench to Bassinet collaborates with BDC by sharing its data in the ecosystem and by offering fellowships to support early-career researchers who leverage its data in BDC.
 
 <ButtonContainer>
-  <ButtonLink to="/about/studies?program=Bench+to+Bassinet">See a list of the Bench to Bassinet data available in BDC</ButtonLink>
+  <ButtonLink to="/about/studies/?program=Bench+to+Bassinet">See a list of the Bench to Bassinet data available in BDC</ButtonLink>
 </ButtonContainer>
 
 ## BioLINCC
@@ -98,7 +98,7 @@ All BioLINCC data and biospecimen are de-identified (obvious subject identifiers
 BDC has ingested some of BioLINCC's data and is working closely with BioLINCC to continue ingesting more BioLINCC data regularly. BioLINCC data are controlled-access data, which means they are available to researchers who have eRA Commons IDs and received data access permissions through the Data Access Request (DAR) process of the NIH's Database of Genotypes and Phenotypes (dbGaP).
 
 <ButtonContainer>
-  <ButtonLink to="/about/studies?program=BioLINCC">See a list of the BioLINCC data available in BDC</ButtonLink>
+  <ButtonLink to="/about/studies/?program=BioLINCC">See a list of the BioLINCC data available in BDC</ButtonLink>
 </ButtonContainer>
 
 ## C4R
@@ -106,7 +106,7 @@ BDC has ingested some of BioLINCC's data and is working closely with BioLINCC to
 The [Collaborative Cohort of Cohorts for COVID-19 Research, or C4R](https://www.c4r-nih.org/), is a "cohort of cohorts" because it brings together 14 cohort studies with participants from across the U.S. to assess COVID-19 infections, vaccinations, hospitalizations, and pandemic experiences in a coordinated manner. While C4R is one of many efforts investigating the effects of COVID-19, it is unique in that the participants were being followed prior to COVID-19 and have undergone multiple detailed health assessments. The goal of C4R is to improve understanding of what factors increase or decrease the likelihood of developing severe COVID-19 or post-acute sequelae of SARS-CoV-2 (PASC). The cohorts are collaborating so that, together, they can help examine both common and more rare COVID-19 outcomes across a race/ethnicity, age, and geographically diverse population.
 
 <ButtonContainer>
-  <ButtonLink to="/about/studies?program=C4R">See a list of the C4R data available in BDC</ButtonLink>
+  <ButtonLink to="/about/studies/?program=C4R">See a list of the C4R data available in BDC</ButtonLink>
 </ButtonContainer>
 
 ## CONNECTS
@@ -114,7 +114,7 @@ The [Collaborative Cohort of Cohorts for COVID-19 Research, or C4R](https://www.
 The NHLBI's [Collaborating Network of Networks for Evaluating COVID-19 and Therapeutic Strategies (CONNECTS)](https://nhlbi-connects.org/) was formed to help prevent infection, slow or halt disease progression, and speed recovery from SARS-CoV-2. The CONNECTS framework includes four therapeutic domains within which clinical trials were conducted: passive immunity, anticoagulation, immunomodulation, and host-tissue targeted therapies.
 
 <ButtonContainer>
-  <ButtonLink to="/about/studies?program=CONNECTS">See a list of the CONNECTS data available in BDC</ButtonLink>
+  <ButtonLink to="/about/studies/?program=CONNECTS">See a list of the CONNECTS data available in BDC</ButtonLink>
 </ButtonContainer>
 
 ## Cure Sickle Cell Initiative 
@@ -136,7 +136,7 @@ Comparator cohort data are currently available. Gene therapy trial data will be 
 HeartShare is comprised of retrospective and prospective components. HeartShare aggregates and harmonizes data from previously completed cohort studies and trials, including images and omics. Prospective data are generated from the HeartShare registry of up to 10,000 participants and deep phenotyping study cohorts involving up to 1,000 participants.  Both cohorts will have baseline and longitudinal data.
 
 <ButtonContainer>
-  <ButtonLink to="/about/studies?program=HeartShare">See a list of the HeartShare data available in BDC</ButtonLink>
+  <ButtonLink to="/about/studies/?program=HeartShare">See a list of the HeartShare data available in BDC</ButtonLink>
 </ButtonContainer>
 
 ## LungMAP
@@ -144,7 +144,7 @@ HeartShare is comprised of retrospective and prospective components. HeartShare 
 The overall objective of the [LungMAP](https://www.lungmap.net/about-lungmap/lungmap-objectives/)  is to build a comprehensive molecular and cellular atlas of the human lung to serve as a reference platform to better understand both normal biology and disease pathobiology and to identify critical cellular components, molecular pathways, and novel therapeutic targets in lung disease. LungMAP continues generating and integrating high-resolution, multiscale molecular profiles associated with spacial information to provide molecular characterizations of functionally and anatomically defined cell types in the human lung.
 
 <ButtonContainer>
-  <ButtonLink to="/about/studies?program=LungMAP">See a list of the LungMAP data available in BDC</ButtonLink>
+  <ButtonLink to="/about/studies/?program=LungMAP">See a list of the LungMAP data available in BDC</ButtonLink>
 </ButtonContainer>
 
 ## National Sleep Research Resource (NSRR) 
@@ -152,7 +152,7 @@ The overall objective of the [LungMAP](https://www.lungmap.net/about-lungmap/lun
 [NSRR](https://sleepdata.org/) is an NHLBI-supported repository for sharing large amounts of sleep data (polysomnography, actigraphy, and questionnaire-based) from multiple cohorts, clinical trials, and other data sources. Launched in April 2014, the mission of the NSRR is to advance sleep and circadian science by supporting secondary data analysis, algorithmic development, and signal processing by sharing high-quality datasets. The NSRR encourages active engagement by the sleep and circadian communities, aiming to expand the breadth and depth of the sleep-related data and understand optimal methods of sleep data analysis.
 
 <ButtonContainer>
-  <ButtonLink to="/about/studies?program=National+Sleep+Research+Resource+%28NSRR%29">See a list of the NSRR data available in BDC</ButtonLink>
+  <ButtonLink to="/about/studies/?program=National+Sleep+Research+Resource+%28NSRR%29">See a list of the NSRR data available in BDC</ButtonLink>
 </ButtonContainer>
 
 ## Pediatric Heart Network
@@ -170,7 +170,7 @@ The [Pediatric Heart Network (PHN)](https://www.pediatricheartnetwork.org/) is a
 The [Clinical Trials Network for the Prevention and Early Treatment of Acute Lung Injury (PETAL Network)](https://petalnet.org/index.html) is a network of 12 Clinical Centers (CC) and 1 Clinical Coordinating Center (CCC) funded by the NHLBI between 2014 and 2023 to develop and conduct randomized controlled clinical trials to prevent or treat, and/or improve the outcome of adult patients who have, or who are at risk for, Acute Lung Injury (ALI) or Acute Respiratory Distress Syndrome (ARDS). During the COVID-19 pandemic, the PETAL Network directed its efforts to better understand the acute and long-term effects of and find treatments for COVID-19.
 
 <ButtonContainer>
-  <ButtonLink to="/about/studies?program=PETAL+Network">See a list of the PETAL Network data available in BDC</ButtonLink>
+  <ButtonLink to="/about/studies/?program=PETAL+Network">See a list of the PETAL Network data available in BDC</ButtonLink>
 </ButtonContainer>
 
 ## Regenerative Medicine Innovation Project (RMIP)


### PR DESCRIPTION
This PR includes three updates:

- Adds the button linking to PHN studies (#265 )
- Fixes the incorrect URL for Sickle Cell Disease studies
- Adds trailing slashes to study links before query parameters to ensure consistent routing