### PR TITLE
permit in-frame freshdesk form

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -197,7 +197,7 @@ module.exports = {
           "img-src": `'self' data: https://widget.freshworks.com`,
           "font-src": `'self' https://fonts.gstatic.com https://widget.freshworks.com`,
           "connect-src": `'self' https://www.google-analytics.com https://widget.freshworks.com https://search.biodatacatalyst.renci.org https://epxuifil2cc4sqfqws62zejcwi0cgfds.lambda-url.us-east-1.on.aws`,
-          "frame-src": `'self' https://www.youtube.com`,
+          "frame-src": `'self' https://www.youtube.com https://bdcatalyst.freshdesk.com`,
           "object-src": `'none'`,
           "base-uri": `'self'`,
         },


### PR DESCRIPTION
this change modifies CSP `frame-src` with `gatsby-plugin-csp` to allow `https://bdcatalyst.freshdesk.com`, which is required for the Freshdesk Contact form to render on the Contact page.