### PR TITLE
update csp by adding bdc freshdesk widget url

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -196,7 +196,7 @@ module.exports = {
           "style-src": `'self' 'unsafe-inline' https://fonts.googleapis.com https://widget.freshworks.com`,
           "img-src": `'self' data: https://widget.freshworks.com`,
           "font-src": `'self' https://fonts.gstatic.com https://widget.freshworks.com`,
-          "connect-src": `'self' https://www.google-analytics.com https://widget.freshworks.com https://search.biodatacatalyst.renci.org https://epxuifil2cc4sqfqws62zejcwi0cgfds.lambda-url.us-east-1.on.aws https://www.google.com https://www.gstatic.com`,
+          "connect-src": `'self' https://www.google-analytics.com https://widget.freshworks.com https://bdcatalyst.freshdesk.com/ https://search.biodatacatalyst.renci.org https://epxuifil2cc4sqfqws62zejcwi0cgfds.lambda-url.us-east-1.on.aws https://www.google.com https://www.gstatic.com`,
           "frame-src": `'self' https://www.youtube.com https://bdcatalyst.freshdesk.com https://www.google.com`,
           "object-src": `'none'`,
           "base-uri": `'self'`,


### PR DESCRIPTION
`https://bdcatalyst.freshdesk.com/ ` was missing from the csp and has now been added.