### PR TITLE
Chore/overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,10 @@
       },
       "devDependencies": {
         "ajv": "8.20.0"
+      },
+      "engines": {
+        "node": "22.x",
+        "npm": ">=10 <12"
       }
     },
     "node_modules/@ardatan/relay-compiler": {
@@ -10082,18 +10086,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/external-editor/node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -16837,15 +16829,6 @@
       "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.5.1.tgz",
       "integrity": "sha512-5VyHfHY3cd0iza71JepYG50My+YUbrFtGoUz2ooEydPyPM7Aai/JW098juLr+RG6+rDJuzNNTsEQu2DZa1A41A=="
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
@@ -17231,9 +17214,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/path-type": {

--- a/package.json
+++ b/package.json
@@ -59,5 +59,9 @@
   },
   "devDependencies": {
     "ajv": "8.20.0"
+  },
+  "overrides": {
+    "path-to-regexp": "0.1.13",
+    "tmp": "0.2.7"
   }
 }


### PR DESCRIPTION
This PR brings in NPM overrides in our `package.json` for:
- path-to-regexp -> 0.1.13
- tmp -> 0.2.7

NPM Audit improved
- From: 52 total, 23 high, 0 critical
- To: 39 total, 19 high, 0 critical

Note:
- path-to-regexp and tmp are patch-level style remediations with low compatibility risk
- riskier overrides for sharp, immutable, serialize-javascript are skipped
  because they are tied to Gatsby internals and may require major upgrades or upstream package changes